### PR TITLE
Added a variety of server metrics to StatusApiHandler

### DIFF
--- a/WaveBox/src/DataModel/Singletons/Settings.cs
+++ b/WaveBox/src/DataModel/Singletons/Settings.cs
@@ -66,8 +66,7 @@ namespace WaveBox.DataModel.Singletons
 			}
 			catch {}
 
-			//Console.WriteLine("settings changed: " + settingsChanged + " port: " + settingsModel.Port);
-			logger.Info("[SETTINGS] settings changed: " + settingsChanged + "port: " + settingsModel.Port);
+			logger.Info("[SETTINGS] settings changed: " + settingsChanged + " | port: " + settingsModel.Port);
 		}
 
 		public static bool WriteSettings(string jsonString)

--- a/WaveBox/src/Transcoding/ITranscoder.cs
+++ b/WaveBox/src/Transcoding/ITranscoder.cs
@@ -26,15 +26,15 @@ namespace WaveBox.Transcoding
 	public enum TranscodeType
 	{
 		// Audio
-		MP3, 
-		AAC, 
+		AAC,
+		MP3,
 		OGG,
         OPUS,
 
 		// Video
 		MP4,
-		X264,
-		MPEGTS
+		MPEGTS,
+		X264
 	}
 
 	public static class TranscodeTypeExtensions

--- a/WaveBox/src/WaveBoxMain.cs
+++ b/WaveBox/src/WaveBoxMain.cs
@@ -41,11 +41,6 @@ namespace WaveBox
 		/// </summary>
 		public static string RootPath()
 		{
-			/*foreach (Environment.SpecialFolder val in Enum.GetValues(typeof(Environment.SpecialFolder)))
-			{
-				logger.Info(val + ": " + Environment.GetFolderPath(val));
-			}*/
-			
 			switch (WaveBoxService.DetectOS())
 			{
 				case WaveBoxService.OS.Windows:
@@ -177,7 +172,7 @@ namespace WaveBox
 		/// </summary>
 		public void Start()
 		{
-			logger.Info("[WAVEBOX] Initializing WaveBox on {0} platform...", Environment.OSVersion.Platform.ToString());
+			logger.Info("[WAVEBOX] Initializing WaveBox on {0} platform...", WaveBoxService.Platform);
 
 			// Create directory for WaveBox's root path, if it doesn't exist
 			string rootDir = RootPath();

--- a/WaveBox/src/WaveBoxService.cs
+++ b/WaveBox/src/WaveBoxService.cs
@@ -16,6 +16,12 @@ namespace WaveBox
 		// Loggererererer... er.
 		private static Logger logger = LogManager.GetCurrentClassLogger();
 
+		// Gather metrics about WaveBox instance
+		// Operating system platform
+		public static string Platform { get; set; }
+		// DateTime object containing the build date of WaveBox (for versioning, status metric)
+		public static DateTime BuildDate { get; set; }
+
 		// Instance of WaveBox, and the thread which will run it
 		private Thread init;
 		private WaveBoxMain wavebox;
@@ -33,6 +39,27 @@ namespace WaveBox
 
 				// Register shutdown handlers for Unix or Windows
 				RegisterShutdownHandler();
+
+				// Gather some metrics about this instance of WaveBox
+				// Operating system detection
+				switch(DetectOS())
+				{
+					case OS.Windows:
+						Platform = "Windows";
+						break;
+					case OS.MacOSX:
+						Platform = "Mac OS X";
+						break;
+					case OS.Unix:
+						Platform = "UNIX/Linux";
+						break;
+					default:
+						Platform = "unknown";
+						break;
+				}
+
+				// Build date detection
+				BuildDate = GetBuildDate();
 
 				// Instantiate a WaveBox object
 				wavebox = new WaveBoxMain();
@@ -264,6 +291,41 @@ namespace WaveBox
 				} 
 			} 
 			return false; 
+		}
+		
+		// Borrowed from: http://stackoverflow.com/questions/1600962/displaying-the-build-date
+		/// <summary>
+		/// Returns a DateTime object containing the date on which WaveBox was compiled (good for nightly build names,
+		/// as well as information on reporting issues which may occur later on.
+		/// </summary>
+		public static DateTime GetBuildDate()
+		{
+			// Read the PE header to get build date
+		    string filePath = System.Reflection.Assembly.GetCallingAssembly().Location;
+		    const int c_PeHeaderOffset = 60;
+		    const int c_LinkerTimestampOffset = 8;
+		    byte[] b = new byte[2048];
+		    System.IO.Stream s = null;
+
+		    try
+		    {
+		        s = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read);
+		        s.Read(b, 0, 2048);
+		    }
+		    finally
+		    {
+		        if (s != null)
+		        {
+					s.Close();
+		        }
+		    }
+
+		    int i = System.BitConverter.ToInt32(b, c_PeHeaderOffset);
+		    int secondsSince1970 = System.BitConverter.ToInt32(b, i + c_LinkerTimestampOffset);
+		    DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0);
+		    dt = dt.AddSeconds(secondsSince1970);
+		    dt = dt.AddHours(TimeZone.CurrentTimeZone.GetUtcOffset(dt).Hours);
+		    return dt;
 		}
 	}
 }


### PR DESCRIPTION
Added some metrics to the StatusApiHandler, including:
- pid
- version
- build date
- platform
- cpu
- memory
- peak memory
- transcoders

Needs further evaluation on Mac and Windows, though it should work fine thanks to Mono.
