### PR TITLE
Add Last-Modified header to Art API handler

### DIFF
--- a/WaveBox/src/ApiHandler/Handlers/ArtApiHandler.cs
+++ b/WaveBox/src/ApiHandler/Handlers/ArtApiHandler.cs
@@ -55,7 +55,6 @@ namespace WaveBox.ApiHandler.Handlers
 			Art art = new Art(artId);
 			Stream stream = art.Stream;
 
-
 			// If the stream could not be produced, return error
 			if ((object)stream == null)
 			{

--- a/WaveBox/src/FolderScanning/FolderScanOperation.cs
+++ b/WaveBox/src/FolderScanning/FolderScanOperation.cs
@@ -180,6 +180,11 @@ namespace WaveBox.FolderScanning
 			{
 				logger.Error("\t" + "[FOLDERSCAN(3)] \"" + folderPath + "\" : " + e);
 			}
+			catch (UnauthorizedAccessException e)
+			{
+				logger.Error("\t" + "[FOLDERSCAN(9)] \"" + folderPath + "\" : Access denied.");
+				logger.Debug("\t" + e);
+			}
 			catch (Exception e)
 			{
 				logger.Error("\t" + "[FOLDERSCAN(4)] \"" + folderPath + "\" : Error checking to see if the file was a directory: " + e);

--- a/WaveBox/src/FolderScanning/OrphanScanOperation.cs
+++ b/WaveBox/src/FolderScanning/OrphanScanOperation.cs
@@ -201,9 +201,9 @@ namespace WaveBox.FolderScanning
 					filename = reader.GetString(reader.GetOrdinal("song_file_name"));
 					path = reader.GetString(reader.GetOrdinal("folder_path")) + Path.DirectorySeparatorChar + filename;
 
-					long timestamp = DateTime.Now.Ticks;
+					long timestamp = DateTime.Now.ToUniversalUnixTimestamp();
 					bool exists = File.Exists(path);
-					totalExistsTime += DateTime.Now.Ticks - timestamp;
+					totalExistsTime += DateTime.Now.ToUniversalUnixTimestamp() - timestamp;
 
 					if (!exists)
 					{

--- a/WaveBox/src/Model/Art.cs
+++ b/WaveBox/src/Model/Art.cs
@@ -90,7 +90,7 @@ namespace WaveBox.Model
 			// compute the hash of the file stream
 			Md5Hash = CalcMd5Hash(fs);
 			FileSize = fs.Length;
-			LastModified = Convert.ToInt64(System.IO.File.GetLastWriteTime(fs.Name).Ticks);
+			LastModified = System.IO.File.GetLastWriteTime(fs.Name).ToUniversalUnixTimestamp();
 			ArtId = Art.ArtIdForMd5(Md5Hash);
 			FilePath = filePath;
 
@@ -109,7 +109,7 @@ namespace WaveBox.Model
 				byte[] data = file.Tag.Pictures[0].Data.Data;
 				Md5Hash = CalcMd5Hash(data);
 				FileSize = data.Length;
-				LastModified = Convert.ToInt64(System.IO.File.GetLastWriteTime(file.Name).Ticks);
+				LastModified = System.IO.File.GetLastWriteTime(file.Name).ToUniversalUnixTimestamp();
 
 				ArtId = Art.ArtIdForMd5(Md5Hash);
 				if (ArtId == null)
@@ -290,7 +290,7 @@ namespace WaveBox.Model
 			// We don't need to instantiate another folder to know what the folder id is.  This should be known when the method is called.
 
 			//Stopwatch sw = new Stopwatch();
-			long lastModified = Convert.ToInt64(System.IO.File.GetLastWriteTime(filePath).Ticks);
+			long lastModified = System.IO.File.GetLastWriteTime(filePath).ToUniversalUnixTimestamp();
 			bool needsUpdating = true;
 
 			IDbConnection conn = null;

--- a/WaveBox/src/Model/Playlist.cs
+++ b/WaveBox/src/Model/Playlist.cs
@@ -131,12 +131,6 @@ namespace WaveBox.Model
 			}
 		}
 
-		public string Md5OfString(string input)
-		{
-			MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
-			return BitConverter.ToString(md5.ComputeHash(System.Text.Encoding.ASCII.GetBytes(input)), 0);
-		}
-
 		// what is the synchronized keyword in java?
 		public string CalculateHash()
 		{
@@ -167,7 +161,7 @@ namespace WaveBox.Model
 				Database.Close(conn, reader);
 			}
 
-			return Md5OfString(itemIds);
+			return itemIds.MD5();
 		}
 
 
@@ -178,7 +172,7 @@ namespace WaveBox.Model
 			PlaylistCount = playlistCount + itemsAdded;
 
 			// update last update time
-			LastUpdateTime = ((DateTime.Now.Ticks / 10) - (new DateTime(1970, 1, 1).Ticks / 10));	// correct?
+			LastUpdateTime = DateTime.Now.ToUniversalUnixTimestamp() - (new DateTime(1970, 1, 1).ToUniversalUnixTimestamp());
 
 			// update playlist duration
 			int? playlistDuration = PlaylistDuration;
@@ -207,7 +201,7 @@ namespace WaveBox.Model
 					PlaylistId = itemId;
 					PlaylistCount = 0;
 					PlaylistDuration = 0;
-					LastUpdateTime = ((DateTime.Now.Ticks / 10) - (new DateTime(1970, 1, 1).Ticks / 10));
+					LastUpdateTime = DateTime.Now.ToUniversalUnixTimestamp() - (new DateTime(1970, 1, 1).ToUniversalUnixTimestamp());
 					q = Database.GetDbCommand("INSERT INTO playlist (playlist_id, playlist_name, playlist_count, playlist_duration, md5_hash, last_update) " +
 											"VALUES (@playlistid, @playlistname, @playlistcount, @playlistduration, @md5, @lastupdate)", conn);
 					//q = Database.GetDbCommand("INSERT INTO playlist VALUES (@playlistid, @playlistname, @playlistcount, @playlistduration, @md5, @lastupdate)");

--- a/WaveBox/src/Model/Song.cs
+++ b/WaveBox/src/Model/Song.cs
@@ -178,7 +178,8 @@ namespace WaveBox.Model
 			Duration = Convert.ToInt32(file.Properties.Duration.TotalSeconds);
 			Bitrate = file.Properties.AudioBitrate;
 			FileSize = fsFile.Length;
-			LastModified = Convert.ToInt64(fsFile.LastWriteTime.Ticks);
+			LastModified = fsFile.LastWriteTime.ToUniversalUnixTimestamp();
+
 			FileName = fsFile.Name;
 
 			// Generate an art id from the embedded art, if it exists
@@ -231,7 +232,7 @@ namespace WaveBox.Model
 		}
 
 		public override void InsertMediaItem()
-		{			
+		{
 			IDbConnection conn = null;
 			IDataReader reader = null;
 			try
@@ -441,7 +442,7 @@ namespace WaveBox.Model
 			// We don't need to instantiate another folder to know what the folder id is.  This should be known when the method is called.
 			//Stopwatch sw = new Stopwatch();
 			string fileName = Path.GetFileName(filePath);
-			long lastModified = Convert.ToInt64(System.IO.File.GetLastWriteTime(filePath).Ticks);
+			long lastModified = System.IO.File.GetLastWriteTime(filePath).ToUniversalUnixTimestamp();
 			bool needsUpdating = true;
 			isNew = true;
 			songId = null;

--- a/WaveBox/src/Model/Video.cs
+++ b/WaveBox/src/Model/Video.cs
@@ -110,7 +110,7 @@ namespace WaveBox.Model
 			Duration = Convert.ToInt32(file.Properties.Duration.TotalSeconds);
 			Bitrate = file.Properties.AudioBitrate;
 			FileSize = fsFile.Length;
-			LastModified = Convert.ToInt64(fsFile.LastWriteTime.Ticks);
+			LastModified = fsFile.LastWriteTime.ToUniversalUnixTimestamp();
 			FileName = fsFile.Name;
 
 			// Generate an art id from the embedded art, if it exists
@@ -285,7 +285,7 @@ namespace WaveBox.Model
 		public static bool VideoNeedsUpdating(string filePath, int? folderId, out bool isNew, out int? songId)
 		{
 			string fileName = Path.GetFileName(filePath);
-			long lastModified = Convert.ToInt64(System.IO.File.GetLastWriteTime(filePath).Ticks);
+			long lastModified = System.IO.File.GetLastWriteTime(filePath).ToUniversalUnixTimestamp();
 			bool needsUpdating = true;
 			isNew = true;
 			songId = null;

--- a/WaveBox/src/Utility.cs
+++ b/WaveBox/src/Utility.cs
@@ -67,6 +67,20 @@ namespace WaveBox
 		}
 
 		/// <summary>
+		/// Generates a MD5 sum of a given string
+		/// <summary>
+		public static string MD5(this string sumthis)
+		{
+			if (sumthis == "" || sumthis == null)
+			{
+				return "";
+			}
+
+			MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
+			return BitConverter.ToString(md5.ComputeHash(System.Text.Encoding.ASCII.GetBytes(sumthis)), 0);
+		}
+
+		/// <summary>
 		/// Returns an integer representation of a month string
 		/// </summary>
 		public static int MonthForAbbreviation(this string abb)


### PR DESCRIPTION
Fix for Issue #64.

I am currently experiencing problems with my "last modified" times on all WaveBox items.  I do not know if this is a Linux issue, a filesystem issue (XFS), or what else it could be.  Will continue to investigate.  For now, I've added a sanity check, which will not add the Last-Modified header if the UNIX timestamp is greater than Int32.MaxValue (See Year 2038 problem).
