### PR TITLE
Move transcode path to predefined temp directory

### DIFF
--- a/WaveBox.Server/src/Transcoding/AbstractTranscoder.cs
+++ b/WaveBox.Server/src/Transcoding/AbstractTranscoder.cs
@@ -58,7 +58,7 @@ namespace WaveBox.Transcoding
 			{ 
 				if (Item != null)
 				{
-					string path = IsDirect ? "-" : TranscodeManager.TRANSCODE_PATH + Path.DirectorySeparatorChar + OutputFilename;
+					string path = IsDirect ? "-" : TranscodeManager.TranscodePath + Path.DirectorySeparatorChar + OutputFilename;
 					return path;
 				}
 

--- a/WaveBox.Server/src/Transcoding/TranscodeManager.cs
+++ b/WaveBox.Server/src/Transcoding/TranscodeManager.cs
@@ -11,7 +11,8 @@ namespace WaveBox.Transcoding
 	{
 		private static readonly log4net.ILog logger = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-		public const string TRANSCODE_PATH = "trans";
+		// Use the system's temp folder to store transcodes
+		public static string TranscodePath = Path.GetTempPath() + "wavebox";
 
 		private TranscodeManager() { }
 		private static readonly TranscodeManager instance = new TranscodeManager();
@@ -21,9 +22,9 @@ namespace WaveBox.Transcoding
 
 		public void Setup()
 		{
-			if (!Directory.Exists(TRANSCODE_PATH)) 
+			if (!Directory.Exists(TranscodePath))
 			{
-				Directory.CreateDirectory(TRANSCODE_PATH);
+				Directory.CreateDirectory(TranscodePath);
 			}
 		}
 		


### PR DESCRIPTION
To me, it seems to make more sense to store temporary files such as transcodes within the system's defined temp directory, rather than one relative to the project root.

In the case of Windows, this would use a path like `C:\Users\Matt\AppData\Local\Temp`, and on UNIX, `/tmp/wavebox`.

EDIT: clarification, this will use the user's defined temp path first (as on Windows), but fall back to the system temp if there isn't one (as on UNIX).
