### PR TITLE
Persistent, commented settings file, even after settings change!

### DIFF
--- a/WaveBox.Core/src/Static/Utility.cs
+++ b/WaveBox.Core/src/Static/Utility.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
@@ -316,6 +317,27 @@ namespace WaveBox.Static
 		public static long ToLocalUnixTimestamp(this DateTime dateTime)
 		{
 			return (long)(dateTime.ToUniversalTime() - new DateTime(1970, 1, 1).ToUniversalTime()).TotalSeconds;
+		}
+
+		/// <summary>
+		/// Convert a List to a quoted CSV string
+		/// </summary>
+		public static string ToCSV(this IList<string> list)
+		{
+			string buffer = "";
+
+			// If list is empty, return empty list
+			if (list.Count == 0)
+			{
+				return "\"\"";
+			}
+
+			foreach (string s in list)
+			{
+				buffer += "\"" + s + "\", ";
+			}
+
+			return buffer.Trim(new char[] {' ', ','});
 		}
 	}
 }

--- a/WaveBox.Server/WaveBox.Server.csproj
+++ b/WaveBox.Server/WaveBox.Server.csproj
@@ -224,6 +224,9 @@
     <None Include="res\wavebox.conf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="res\wavebox.conf.template">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="lib\Mono.Zeroconf.dll" />
     <None Include="lib\Mono.Zeroconf.Providers.Bonjour.dll" />
     <None Include="Mono.Zeroconf.Providers.Bonjour.dll.config">

--- a/WaveBox.Server/res/wavebox.conf.template
+++ b/WaveBox.Server/res/wavebox.conf.template
@@ -1,0 +1,42 @@
+/*
+	WaveBox.conf
+
+	Defines settings for the WaveBox server.  Everything here is also modifiable from the web ui, so
+	if you're unfamiliar with JSON notation, you may wish to use that.  Malformed JSON will result
+	in the server not running.
+*/
+
+{
+	// Choose the port for WaveBox to listen on. Remember that if choosing a port under 1024, WaveBox will need to be run as root
+	"port": {setting-port},
+	
+	// Choose the port for WaveBox's WebSockets interface to listen on
+	"wsPort": {setting-wsPort},
+
+	// Choose whether to automatically report WaveBox crashes.  It is STRONGLY suggested to leave this set to 'true'
+	"crashReportEnable": {setting-crashReportEnable},
+
+	// Choose whether or not to enable NAT for UPnP/NAT-PMP. Setting to false will require manual router configuration
+	"natEnable": {setting-natEnable},
+
+	// Define your media folders here.  They are comma-delimited between the brackets, e.g. ["path1", "path2"]
+	"mediaFolders": [{setting-mediaFolders}],
+
+	// This is where WaveBox will store podcasts it downloads from the feeds you provide
+	"podcastFolder": "{setting-podcastFolder}",
+
+	// Defines how often WaveBox will check for new podcasts (in minutes)
+	"podcastCheckInterval": {setting-podcastCheckInterval},
+
+	// Defines how long a session may remain idle before being purged by the session scrubber (in minutes)
+	"sessionTimeout": {setting-sessionTimeout},
+
+	// Defines how often WaveBox will purge unused sessions (in minutes)
+	"sessionScrubInterval": {setting-sessionScrubInterval},
+
+	// Choose whether to enable pretty formatting for API responses. Setting to false reduces the response size
+	"prettyJson": {setting-prettyJson},
+	
+	// Defines the order that folder art is searched for
+	"folderArtNames": [{setting-folderArtNames}]
+}


### PR DESCRIPTION
- Settings template file, so that changing settings does not destroy the commented wavebox.conf
- Settings hardening
- ToCSV() method for lists
- Exception handling everywhere!

Basically, this will write the user's settings into the wavebox.conf.template file, then save that file on each settings write.  This allows us to preserve a well-formatted and well-documented settings file, even when settings are changed on the fly.
