### PR TITLE
Remove some redundant API naming, remove unused eventType on Last.fm

### DIFF
--- a/WaveBox.Server/src/ApiHandler/Handlers/PodcastApiHandler.cs
+++ b/WaveBox.Server/src/ApiHandler/Handlers/PodcastApiHandler.cs
@@ -48,31 +48,31 @@ namespace WaveBox.ApiHandler.Handlers
 					{
 						if (action == "add")
 						{
-							if ((Uri.Parameters.ContainsKey("podcastUrl")) && (Uri.Parameters.ContainsKey("podcastKeepCap")))
+							if ((Uri.Parameters.ContainsKey("url")) && (Uri.Parameters.ContainsKey("keepCap")))
 							{
-								string podcastUrl = null;
+								string url = null;
 								string keepCapTemp = null;
 								int keepCap = 0;
-								Uri.Parameters.TryGetValue("podcastUrl", out podcastUrl);
-								Uri.Parameters.TryGetValue("podcastKeepCap", out keepCapTemp);
+								Uri.Parameters.TryGetValue("url", out url);
+								Uri.Parameters.TryGetValue("keepCap", out keepCapTemp);
 
-								if (podcastUrl == null)
+								if (url == null)
 								{
-									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'podcastUrl' contained an invalid value", null), Settings.JsonFormatting));
+									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'url' contained an invalid value", null), Settings.JsonFormatting));
 								}
 
 								else if (keepCapTemp == null)
 								{
-									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'podcastKeepCap' contained an invalid value", null), Settings.JsonFormatting));
+									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'keepCap' contained an invalid value", null), Settings.JsonFormatting));
 								}
 								else 
 								{
 									if (!Int32.TryParse(keepCapTemp, out keepCap))
 									{
-										Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'podcastKeepCap' contained an invalid value", null), Settings.JsonFormatting));
+										Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Parameter 'keepCap' contained an invalid value", null), Settings.JsonFormatting));
 									}
-									podcastUrl = System.Web.HttpUtility.UrlDecode(podcastUrl);
-									Podcast pod = new Podcast(podcastUrl, keepCap);
+									url = System.Web.HttpUtility.UrlDecode(url);
+									Podcast pod = new Podcast(url, keepCap);
 									pod.DownloadNewEpisodes();
 									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse(null, null), Settings.JsonFormatting));
 									return;
@@ -85,22 +85,22 @@ namespace WaveBox.ApiHandler.Handlers
 						}
 						else if (action == "delete")
 						{
-							if (!(Uri.Parameters.ContainsKey("podcastId") || Uri.Parameters.ContainsKey("podcastEpisodeId")))
+							if (!(Uri.Parameters.ContainsKey("id") || Uri.Parameters.ContainsKey("episodeId")))
 							{
 								Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Missing parameter for action 'delete'", null), Settings.JsonFormatting));
 								return;
 							}
-							else if (Uri.Parameters.ContainsKey("podcastId") && Uri.Parameters.ContainsKey("podcastEpisodeId"))
+							else if (Uri.Parameters.ContainsKey("id") && Uri.Parameters.ContainsKey("episodeId"))
 							{
-								Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Ambiguous parameters for action 'delete'.  'delete' accepts either a podcastId or a podcastEpisodeId, but not both.", null), Settings.JsonFormatting));
+								Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse("Ambiguous parameters for action 'delete'.  'delete' accepts either a id or a episodeId, but not both.", null), Settings.JsonFormatting));
 								return;
 							}
-							else if (Uri.Parameters.ContainsKey("podcastId"))
+							else if (Uri.Parameters.ContainsKey("id"))
 							{
 								int id = 0;
 								string idString = null;
 
-								Uri.Parameters.TryGetValue("podcastId", out idString);
+								Uri.Parameters.TryGetValue("id", out idString);
 								if (Int32.TryParse(idString, out id))
 								{
 									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse(null, new Podcast(id).Delete()), Settings.JsonFormatting));
@@ -108,7 +108,7 @@ namespace WaveBox.ApiHandler.Handlers
 								}
 								else
 								{
-									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse("Parameter 'podcastId' contained an invalid value", false), Settings.JsonFormatting));
+									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse("Parameter 'id' contained an invalid value", false), Settings.JsonFormatting));
 									return;
 								}
 							}
@@ -117,7 +117,7 @@ namespace WaveBox.ApiHandler.Handlers
 								int id = 0;
 								string idString = null;
 
-								Uri.Parameters.TryGetValue("podcastEpisodeId", out idString);
+								Uri.Parameters.TryGetValue("episodeId", out idString);
 								if (Int32.TryParse(idString, out id))
 								{
 									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse(null, new PodcastEpisode(id).Delete()), Settings.JsonFormatting));
@@ -125,7 +125,7 @@ namespace WaveBox.ApiHandler.Handlers
 								}
 								else
 								{
-									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse("Parameter 'podcastEpisodeId' contained an invalid value", false), Settings.JsonFormatting));
+									Processor.WriteJson(JsonConvert.SerializeObject(new PodcastActionResponse("Parameter 'episodeId' contained an invalid value", false), Settings.JsonFormatting));
 									return;
 								}
 							}
@@ -139,12 +139,12 @@ namespace WaveBox.ApiHandler.Handlers
 			}
 			else
 			{
-				int podcastId = 0;
-				Int32.TryParse(Uri.UriPart(2), out podcastId);
+				int id = 0;
+				Int32.TryParse(Uri.UriPart(2), out id);
 
-				if (podcastId != 0)
+				if (id != 0)
 				{
-					Podcast thisPodcast = new Podcast(podcastId);
+					Podcast thisPodcast = new Podcast(id);
 					List<PodcastEpisode> epList = thisPodcast.ListOfStoredEpisodes();
 
 					Processor.WriteJson(JsonConvert.SerializeObject(new PodcastContentResponse(null, thisPodcast, epList), Settings.JsonFormatting));

--- a/WaveBox.Server/src/ApiHandler/Handlers/ScrobbleApiHandler.cs
+++ b/WaveBox.Server/src/ApiHandler/Handlers/ScrobbleApiHandler.cs
@@ -39,11 +39,9 @@ namespace WaveBox.ApiHandler.Handlers
 			// Pull URL parameters for Last.fm integration
 			string action = null;
 			string eve = null;
-			string eveType = null;
 
 			Uri.Parameters.TryGetValue("action", out action);
 			Uri.Parameters.TryGetValue("event", out eve);
-			Uri.Parameters.TryGetValue("eventType", out eveType);
 
 			if (action == null || action == "auth")
 			{

--- a/WaveBox.Server/src/ApiHandler/Handlers/SettingsApiHandler.cs
+++ b/WaveBox.Server/src/ApiHandler/Handlers/SettingsApiHandler.cs
@@ -23,16 +23,16 @@ namespace WaveBox.ApiHandler
 
 		public void Process()
 		{
-			if (Uri.Parameters.ContainsKey("settingsJson"))
+			if (Uri.Parameters.ContainsKey("json"))
 			{
 				// Take in settings in the JSON format (same as it is stored on disk) and pass it on to the Settings class for processing=
-				string settingsJson = Uri.Parameters["settingsJson"];
+				string json = Uri.Parameters["json"];
 
 				// Attempt to write settings
 				bool success = false;
 				try
 				{
-					success = Settings.WriteSettings(settingsJson);
+					success = Settings.WriteSettings(json);
 				}
 				catch (JsonException)
 				{


### PR DESCRIPTION
Last.fm
- remove unused eventType

Podcast:
- podcastId -> id
- podcastUrl -> url
- podcastEpisodeId -> episodeId
- podcastKeepCap -> keepCap

Settings:
- settingsJson -> json
