### PR TITLE
Remove SessionScrubInterval because SessionTimeout is configurable anyway

### DIFF
--- a/WaveBox.Core/src/Injected/IServerSettings.cs
+++ b/WaveBox.Core/src/Injected/IServerSettings.cs
@@ -26,8 +26,6 @@ namespace WaveBox.Core.Injected
 
 		int PodcastCheckInterval { get; }
 
-		int SessionScrubInterval { get; }
-
 		int SessionTimeout { get; }
 
 		List<Folder> MediaFolders { get; }

--- a/WaveBox.Core/src/Model/ServerSettingsData.cs
+++ b/WaveBox.Core/src/Model/ServerSettingsData.cs
@@ -27,9 +27,6 @@ namespace WaveBox.Model
 		[JsonProperty("podcastCheckInterval")]
 		public int PodcastCheckInterval { get; set; }
 
-		[JsonProperty("sessionScrubInterval")]
-		public int SessionScrubInterval { get; set; }
-
 		[JsonProperty("sessionTimeout")]
 		public int SessionTimeout { get; set; }
 

--- a/WaveBox.Server/res/wavebox.conf
+++ b/WaveBox.Server/res/wavebox.conf
@@ -31,9 +31,6 @@
 	// Defines how long a session may remain idle before being purged by the session scrubber (in minutes)
 	"sessionTimeout": 120,
 
-	// Defines how often WaveBox will purge unused sessions (in minutes)
-	"sessionScrubInterval": 60,
-
 	// Choose whether to enable pretty formatting for API responses. Setting to false reduces the response size
 	"prettyJson": true,
 	

--- a/WaveBox.Server/res/wavebox.conf.template
+++ b/WaveBox.Server/res/wavebox.conf.template
@@ -31,9 +31,6 @@
 	// Defines how long a session may remain idle before being purged by the session scrubber (in minutes)
 	"sessionTimeout": {setting-sessionTimeout},
 
-	// Defines how often WaveBox will purge unused sessions (in minutes)
-	"sessionScrubInterval": {setting-sessionScrubInterval},
-
 	// Choose whether to enable pretty formatting for API responses. Setting to false reduces the response size
 	"prettyJson": {setting-prettyJson},
 	

--- a/WaveBox.Server/src/SessionManagement/SessionScrubOperation.cs
+++ b/WaveBox.Server/src/SessionManagement/SessionScrubOperation.cs
@@ -53,8 +53,8 @@ namespace WaveBox
 		{
 			SessionScrub.Start();
 
-			// Queue up the next one
-			SessionScrub.Queue.queueOperation(new SessionScrubOperation(Injection.Kernel.Get<IServerSettings>().SessionScrubInterval));
+			// Queue up the next one in one hour
+			SessionScrub.Queue.queueOperation(new SessionScrubOperation(60));
 		}
 
 		// No need to cancel this operation

--- a/WaveBox.Server/src/Static/ServerSettings.cs
+++ b/WaveBox.Server/src/Static/ServerSettings.cs
@@ -38,14 +38,11 @@ namespace WaveBox.Static
 
 		public int PodcastCheckInterval { get { return settingsModel.PodcastCheckInterval; } }
 
-		public int SessionScrubInterval { get { return settingsModel.SessionScrubInterval; } }
-
 		public int SessionTimeout { get { return settingsModel.SessionTimeout; } }
 
 		public List<Folder> MediaFolders { get; private set; }
 
 		public List<string> FolderArtNames { get { return settingsModel.FolderArtNames; } }
-
 
 		public void Reload()
 		{
@@ -199,18 +196,6 @@ namespace WaveBox.Static
 
 			try
 			{
-				int? sessionScrubIntervalTemp = json.sessionScrubInterval;
-				if (sessionScrubIntervalTemp != null)
-				{
-					settingsModel.SessionScrubInterval = (int)sessionScrubIntervalTemp;
-					settingsChanged = true;
-					if (logger.IsInfoEnabled) logger.Info("Setting 'sessionScrubInterval': " + settingsModel.SessionScrubInterval);
-				}
-			}
-			catch { }
-
-			try
-			{
 				int? sessionTimeoutTemp = json.sessionTimeout;
 				if (sessionTimeoutTemp != null)
 				{
@@ -291,7 +276,6 @@ namespace WaveBox.Static
 					.Replace("{setting-podcastFolder}", settingsModel.PodcastFolder)
 					.Replace("{setting-podcastCheckInterval}", settingsModel.PodcastCheckInterval.ToString())
 					.Replace("{setting-sessionTimeout}", settingsModel.SessionTimeout.ToString())
-					.Replace("{setting-sessionScrubInterval}", settingsModel.SessionScrubInterval.ToString())
 					.Replace("{setting-prettyJson}", settingsModel.PrettyJson.ToString().ToLower())
 					.Replace("{setting-folderArtNames}", settingsModel.FolderArtNames.ToCSV(true));
 			}


### PR DESCRIPTION
Title says it.  Stale sessions will be checked each hour, and if they have been idle longer than SessionTimeout minutes, they will be scrubbed.  Having two options for essentially the same mechanism is redundant.
