### PR TITLE
Add limit and range functionality Song model, API handler

### DIFF
--- a/WaveBox.Server/src/ApiHandler/Handlers/SongsApiHandler.cs
+++ b/WaveBox.Server/src/ApiHandler/Handlers/SongsApiHandler.cs
@@ -36,27 +36,126 @@ namespace WaveBox.ApiHandler.Handlers
 			IList<Song> listOfSongs = new List<Song>();
 
 			// Fetch song ID from parameters
-			bool success = false;
 			int id = 0;
 			if (Uri.Parameters.ContainsKey("id"))
 			{
-				success = Int32.TryParse(Uri.Parameters["id"], out id);
-			}
+				if (!Int32.TryParse(Uri.Parameters["id"], out id))
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'id' requires a valid integer", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
 
-			if (success)
-			{
 				// Add song by ID to the list
 				listOfSongs.Add(new Song.Factory().CreateSong(id));
 			}
-			else
+			// Check for a request for range of songs
+			else if (Uri.Parameters.ContainsKey("range"))
 			{
-				// Add all songs to list
+				string[] range = Uri.Parameters["range"].Split(',');
+
+				// Ensure valid range was parsed
+				if (range.Length != 2)
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'range' requires a valid, comma-separated character tuple", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
+
+				// Validate as characters
+				char start, end;
+				if (!Char.TryParse(range[0], out start) || !Char.TryParse(range[1], out end))
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'range' requires characters which are single alphanumeric values", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
+
+				// Grab range of songs
+				listOfSongs = Song.RangeSongs(start, end);
+			}
+
+			// Check for a request to limit/paginate songs, like SQL
+			// Note: can be combined with range or all songs
+			if (Uri.Parameters.ContainsKey("limit") && !Uri.Parameters.ContainsKey("id"))
+			{
+				string[] limit = Uri.Parameters["limit"].Split(',');
+
+				// Ensure valid limit was parsed
+				if (limit.Length < 1 || limit.Length > 2 )
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'limit' requires a single integer, or a valid, comma-separated integer tuple", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
+
+				// Validate as integers
+				int index = 0;
+				int duration = Int32.MinValue;
+				if (!Int32.TryParse(limit[0], out index))
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'limit' requires a valid integer start index", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
+
+				// Ensure positive index
+				if (index < 0)
+				{
+					string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'limit' requires a non-negative integer start index", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+					Processor.WriteJson(json);
+					return;
+				}
+
+				// Check for duration
+				if (limit.Length == 2)
+				{
+					if (!Int32.TryParse(limit[1], out duration))
+					{
+						string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'limit' requires a valid integer duration", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+						Processor.WriteJson(json);
+						return;
+					}
+
+					// Ensure positive duration
+					if (duration < 0)
+					{
+						string json = JsonConvert.SerializeObject(new SongsResponse("Parameter 'limit' requires a non-negative integer duration", null), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
+						Processor.WriteJson(json);
+						return;
+					}
+				}
+
+				// Check if results list already populated by range
+				if (listOfSongs.Count > 0)
+				{
+					// No duration?  Return just specified number of songs
+					if (duration == Int32.MinValue)
+					{
+						listOfSongs = listOfSongs.Skip(0).Take(index).ToList();
+					}
+					else
+					{
+						// Else, return songs starting at index, up to count duration
+						listOfSongs = listOfSongs.Skip(index).Take(duration).ToList();
+					}
+				}
+				else
+				{
+					// If no songs in list, grab directly using model method
+					listOfSongs = Song.LimitSongs(index, duration);
+				}
+			}
+
+			// Finally, if no songs already in list, send the whole list
+			if (listOfSongs.Count == 0)
+			{
 				listOfSongs = Song.AllSongs();
 			}
 
-			// Return generated list of songs
 			try
 			{
+				// Send it!
 				string json = JsonConvert.SerializeObject(new SongsResponse(null, listOfSongs), Injection.Kernel.Get<IServerSettings>().JsonFormatting);
 				Processor.WriteJson(json);
 			}


### PR DESCRIPTION
This one's a doozy, but it basically allows the following:

Return one song:
http://localhost:6500/api/songs?id=1

Return all songs:
http://localhost:6500/api/songs

Return all songs in range C-F
http://localhost:6500/api/songs?range=C,F

Return 10 songs
http://localhost:6500/api/songs?limit=10

Return 10 songs, starting at index 10
http://localhost:6500/api/songs?limit=10,10

Return 3 songs in range C-F
http://localhost:6500/api/songs?range=C,F&limit=3

Return 3 songs in range C-F, starting at index 10
http://localhost:6500/api/songs?range=C,F&limit=10,3

Phew.  Let me know how you guys feel about this one.  I tried to be as faithful as possible to the SQL results, while trying to not pull more results than I need.
