### PR TITLE
Add necessary joins in Song.SearchSongs()

### DIFF
--- a/WaveBox.Core/src/Model/Song.cs
+++ b/WaveBox.Core/src/Model/Song.cs
@@ -247,12 +247,20 @@ namespace WaveBox.Model
 				if (exact)
 				{
 					// Search for exact match
-					songs = conn.Query<Song>("SELECT * FROM Song WHERE " + field + " = ?", query);
+					songs = conn.Query<Song>("SELECT Song.*, Artist.ArtistName, Album.AlbumName, Genre.GenreName FROM Song " +
+											"LEFT JOIN Artist ON Song.ArtistId = Artist.ArtistId " +
+											"LEFT JOIN Album ON Song.AlbumId = Album.AlbumId " +
+											"LEFT JOIN Genre ON Song.GenreId = Genre.GenreId " +
+											"WHERE Song." + field + " = ?", query);
 				}
 				else
 				{
 					// Search for fuzzy match (containing query)
-					songs = conn.Query<Song>("SELECT * FROM Song WHERE " + field + " LIKE ?", "%" + query + "%");
+					songs = conn.Query<Song>("SELECT Song.*, Artist.ArtistName, Album.AlbumName, Genre.GenreName FROM Song " +
+											"LEFT JOIN Artist ON Song.ArtistId = Artist.ArtistId " +
+											"LEFT JOIN Album ON Song.AlbumId = Album.AlbumId " +
+											"LEFT JOIN Genre ON Song.GenreId = Genre.GenreId " +
+											"WHERE Song." + field + " LIKE ?", "%" + query + "%");
 				}
 				songs.Sort(Song.CompareSongsByDiscAndTrack);
 				return songs;


### PR DESCRIPTION
Fixes to ensure Artist, Album, and Genre information are displayed when Song.SearchSongs() is called. (Used in Folders API, this fixes null output on those fields)
