### PR TITLE
Don't let filemanager fail to start when no valid media folders defined

### DIFF
--- a/WaveBox.Server/src/Service/Services/FileManagerService.cs
+++ b/WaveBox.Server/src/Service/Services/FileManagerService.cs
@@ -116,8 +116,7 @@ namespace WaveBox.Service.Services
 			// Report if no media folders in configuration
 			if (mediaFolders.Count == 0)
 			{
-				logger.Warn("No media folders defined, cannot start FileManager service");
-				return false;
+				logger.Warn("No media folders defined, FileManager service cannot find any media");
 			}
 
 			// Collect garbage now to conserve resources


### PR DESCRIPTION
Patch at Ben's request, should fix issue #122.
