### PR TITLE
Strip all trailing slashes, to ensure folders are stored correctly

### DIFF
--- a/WaveBox.Server/src/Static/ServerSettings.cs
+++ b/WaveBox.Server/src/Static/ServerSettings.cs
@@ -77,7 +77,7 @@ namespace WaveBox.Static
 
 			dynamic json = JsonConvert.DeserializeObject(configFile);
 			bool settingsChanged = false;
-			
+
 			try
 			{
 				string podcastFolderTemp = json.podcastFolderDoesntExist;
@@ -339,7 +339,7 @@ namespace WaveBox.Static
 
 					settingsTemplate.Close();
 					settingsOut.Close();
-				} 
+				}
 				catch (Exception e)
 				{
 					logger.Error(e);
@@ -391,6 +391,9 @@ namespace WaveBox.Static
 			ISQLiteConnection conn = null;
 			try
 			{
+				// Trim all trailing slashes from paths, to prevent potential constraint issues
+				path = path.TrimEnd('/', '\\');
+
 				conn = Injection.Kernel.Get<IDatabase>().GetSqliteConnection();
 				IList<Folder> result = conn.Query<Folder>("SELECT * FROM Folder WHERE FolderPath = ? AND MediaFolderId IS NULL", path);
 
@@ -425,7 +428,7 @@ namespace WaveBox.Static
 			bool inBlockComment = false;
 			bool inStringLiteral = false;
 
-			Action<char> AppendDiscardingWhitespace = (c) => 
+			Action<char> AppendDiscardingWhitespace = (c) =>
 			{
 				if (c != '\t' && c != ' ')
 				{
@@ -490,7 +493,7 @@ namespace WaveBox.Static
 							continue;
 						}
 					}
-					else 
+					else
 					{
 						// if we are in a block comment, make sure that we shouldn't be ending the block comment
 						if (curr == '*' && next == '/')


### PR DESCRIPTION
This has been an issue for a while, but I totally forgot about it.  If you specify media folders with a trailing slash like so:

`"mediaFolders": ["/srv/media/Music/FLAC/Atreyu", "/srv/media/Music/FLAC/Boston/"],`

The "Boston" folder will not appear in `/api/folders`, but its contents will appear in `/api/albums`.  This fixes that.
