### PR TITLE
Fix executable path detection, add absolute paths to resource files

### DIFF
--- a/WaveBox.Server/src/Static/Database.cs
+++ b/WaveBox.Server/src/Static/Database.cs
@@ -17,11 +17,11 @@ namespace WaveBox.Static
 		private static readonly log4net.ILog logger = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		private static readonly string DATABASE_FILE_NAME = "wavebox.db";
-		public string DatabaseTemplatePath { get { return "res" + Path.DirectorySeparatorChar + DATABASE_FILE_NAME; } }
+		public string DatabaseTemplatePath { get { return ServerUtility.ExecutablePath() + "res" + Path.DirectorySeparatorChar + DATABASE_FILE_NAME; } }
 		public string DatabasePath { get { return ServerUtility.RootPath() + DATABASE_FILE_NAME; } }
 
 		private static readonly string QUERY_LOG_FILE_NAME = "wavebox_querylog.db";
-		public string QuerylogTemplatePath { get { return "res" + Path.DirectorySeparatorChar + QUERY_LOG_FILE_NAME; } }
+		public string QuerylogTemplatePath { get { return ServerUtility.ExecutablePath() + "res" + Path.DirectorySeparatorChar + QUERY_LOG_FILE_NAME; } }
 		public string QuerylogPath { get { return ServerUtility.RootPath() + QUERY_LOG_FILE_NAME; } }
 
 		private static readonly object dbBackupLock = new object();

--- a/WaveBox.Server/src/Static/ServerSettings.cs
+++ b/WaveBox.Server/src/Static/ServerSettings.cs
@@ -20,7 +20,7 @@ namespace WaveBox.Static
 		private static readonly log4net.ILog logger = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		private static readonly string settingsFileName = "wavebox.conf";
-		public string SettingsTemplatePath() { return "res" + Path.DirectorySeparatorChar + settingsFileName; }
+		public string SettingsTemplatePath() { return ServerUtility.ExecutablePath() + "res" + Path.DirectorySeparatorChar + settingsFileName; }
 		public string SettingsPath() { return ServerUtility.RootPath() + settingsFileName; }
 
 		private ServerSettingsData settingsModel = new ServerSettingsData();

--- a/WaveBox.Server/src/Static/ServerUtility.cs
+++ b/WaveBox.Server/src/Static/ServerUtility.cs
@@ -278,7 +278,7 @@ namespace WaveBox
 		/// </summary>
 		public static string ExecutablePath()
 		{
-			return Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar;
+			return AppDomain.CurrentDomain.BaseDirectory;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This forces WaveBox to use the correct paths for resource files and themes, regardless of the working directory in which it is executed.
