### PR TITLE
RESTful ID passing, by injecting ID parameter into UriWrapper

### DIFF
--- a/WaveBox.Server/src/ApiHandler/UriWrapper.cs
+++ b/WaveBox.Server/src/ApiHandler/UriWrapper.cs
@@ -54,7 +54,7 @@ namespace WaveBox.ApiHandler
 			if (Int32.TryParse(this.LastPart, out id))
 			{
 				// Add ID parameter if found
-				this.Parameters.Add("id", id.ToString());
+				this.Parameters["id"] = id.ToString();
 			}
 		}
 


### PR DESCRIPTION
This allows both: `/api/songs/6` and `/api/songs?id=6` to behave identically.  Any API handler which uses "id" can have its ID injected in a RESTful way.
