### PR TITLE
Ensure genres API returns the genre being selected by ID

### DIFF
--- a/WaveBox.Server/src/ApiHandler/Handlers/GenresApiHandler.cs
+++ b/WaveBox.Server/src/ApiHandler/Handlers/GenresApiHandler.cs
@@ -46,7 +46,9 @@ namespace WaveBox.ApiHandler.Handlers
 					type = uri.Parameters["type"];
 				}
 
+				// Get single genre, add it for output
 				Genre genre = Injection.Kernel.Get<IGenreRepository>().GenreForId(id);
+				listOfGenres.Add(genre);
 
 				switch (type)
 				{


### PR DESCRIPTION
Makes behavior consistent with the rest of the API, which returns the object in question when selecting by ID.
