### PR TITLE
Remove patch for passing IDs via old GET parameter convention

### DIFF
--- a/WaveBox.Server/src/ApiHandler/UriWrapper.cs
+++ b/WaveBox.Server/src/ApiHandler/UriWrapper.cs
@@ -65,12 +65,6 @@ namespace WaveBox.ApiHandler
 				this.Action = this.Parameters["action"];
 			}
 
-			// Compatibility patch until web client is updated to pass URLs the REST way
-			if (this.Parameters.ContainsKey("id"))
-			{
-				this.Id = Convert.ToInt32(this.Parameters["id"]);
-			}
-
 			// Check for ID passed in REST form (e.g. /api/songs/6)
 			// NOTE: try/catch'd to avoid exceptions thrown on web UI loading
 			try


### PR DESCRIPTION
This commit will completely remove support for this: `/api/albums?id=1`, in favor of this `/api/albums/1`.
