### PR TITLE
Add caching on user lookup methods: UserForId, UserForName, UserNameForSessionId

### DIFF
--- a/WaveBox.Core/src/Repository/Interfaces/IUserRepository.cs
+++ b/WaveBox.Core/src/Repository/Interfaces/IUserRepository.cs
@@ -10,7 +10,7 @@ namespace WaveBox.Core.Model.Repository
 		User UserForName(string userName);
 		User CreateUser(string userName, string password, Role role, long? deleteTime);
 		User CreateTestUser(long? durationSeconds);
-		string UserNameForSessionid(string sessionId);
+		string UserNameForSessionId(string sessionId);
 		IList<User> AllUsers();
 		IList<User> ExpiredUsers();
 	}

--- a/WaveBox.Server/src/ApiHandler/ApiAuthenticate.cs
+++ b/WaveBox.Server/src/ApiHandler/ApiAuthenticate.cs
@@ -19,7 +19,7 @@ namespace WaveBox.ApiHandler
 		/// </summary>
 		public User AuthenticateSession(string session)
 		{
-			string username = Injection.Kernel.Get<IUserRepository>().UserNameForSessionid(session);
+			string username = Injection.Kernel.Get<IUserRepository>().UserNameForSessionId(session);
 			if (username != null)
 			{
 				User user = Injection.Kernel.Get<IUserRepository>().UserForName(username);


### PR DESCRIPTION
Basic caching using a dictionary for each of these methods.  The memory footprint will be small enough that I think it makes more sense to use these separate caches, rather than attempting to unify them.

Because we currently do not provide an API to update users, the users will remain cached indefinitely once fetched by the server. Will modify this in the future.
